### PR TITLE
Pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+# command to install dependencies
+install: "pip install -r test-requirement.txt"
+# command to run tests
+script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+   - "2.6"
+   - "2.7"
+   - "3.2"
+   - "3.3"
+   - "3.4"
+   - "3.5"
 # command to install dependencies
+before_install:
+   - sudo apt-get update -qq
+   - sudo apt-get install -y strace
 install: "pip install -r test-requirement.txt"
 # command to run tests
 script: py.test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+
+[![Build
+Status](https://travis-ci.org/matclab/fabricate.svg?branch=pytest)](https://travis-ci.org/matclab/fabricate)
+
+**fabricate** is a build tool that finds dependencies automatically for any language. It's small and just works. No hidden stuff behind your back. It was inspired by Bill McCloskey's make replacement, memoize, but fabricate works on [Windows](HowItWorks#Windows_Issues.md) as well as Linux.
+
+[Get fabricate.py now](https://fabricate.googlecode.com/git/fabricate.py), learn [how it works](HowItWorks.md), see how to get [in-Python help](Help.md), or discuss it on the [mailing list](http://groups.google.com/group/fabricate-users).
+
+## Features ##
+
+  * Never have to list dependencies.
+  * Never have to specify cleanup rules.
+  * The tool is a single Python file.
+  * It uses MD5 (not timestamps) to check inputs and outputs.
+  * You can learn it all in about 10 minutes.
+  * You can still read your build scripts 3 months later.
+  * Now supports [parallel building](ParallelBuilding.md)
+
+## Show me an example! ##
+
+```
+from fabricate import *
+
+sources = ['program', 'util']
+
+def build():
+    compile()
+    link()
+
+def compile():
+    for source in sources:
+        run('gcc', '-c', source+'.c')
+
+def link():
+    objects = [s+'.o' for s in sources]
+    run('gcc', '-o', 'program', objects)
+
+def clean():
+    autoclean()
+
+main()
+```
+
+This isn't the simplest build script you can make with fabricate (see [other examples](Examples.md)), but it's surprisingly close to some of the more complex scripts we use in real life. Things to note:
+
+  * It's an **ordinary Python file.** Use the clarity and power of Python.
+  * **No implicit stuff** like CCFLAGS.
+  * **Explicit is better:** you tell fabricate what commands to run, and it runs them -- but only if their inputs or outputs have changed.
+  * Where you'd use targets in make, you just **use Python functions** -- `build()` is the default.
+  * You can **easily "autoclean"** any build outputs -- fabricate finds build outputs automatically, just like it finds dependencies.
+
+## Using fabricate options ##
+
+The best way to get started is to take one of the examples linked above and modify it to suit your project.  But you're bound to want to use some of the options built into fabricate.  To get a list of these:
+```
+ from fabricate import *
+
+ help(main)
+ help(Builder)
+```
+
+## Using fabricate as a script, a la memoize ##
+
+You can also use fabricate.py as a script and enter commands directly on the command line (see [command line options](CommandLineOptions.md)). In the following, each `gcc` command will only be run if its dependencies have changed:
+
+```
+fabricate.py gcc -c program.c
+fabricate.py gcc -c util.c
+fabricate.py gcc -o program program.o util.o
+```
+
+## Why not use make? ##
+
+For a start, fabricate won't say "`*** missing separator`" if you use spaces instead of tabs. And you'll never need to enter dependencies manually, like this:
+
+```
+files.o : files.c defs.h buffer.h command.h
+        cc -c files.c
+```
+
+Instead, you just tell fabricate to `run('cc', 'file.c')` and it'll figure out what that command's inputs and outputs are. Next time you build, the command will only get run if its inputs have changed, or if its outputs have been modified or aren't there.
+
+And you can use Python's readable string functions instead of producing write-only make rules, like this one from the make docs:
+
+```
+%.d : %.c
+        @set -e; rm -f $@; $(CC) -M $(CPPFLAGS) $< > $@.$$$$; \
+        sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; rm -f $@.$$$$
+```
+
+## What about SCons? ##
+
+SCons tempted us at first too. It's Python ... isn't it? But just before it sucks you in, you realise it's actually [quite hard](http://stackoverflow.com/questions/1074062/) to do simple things explicitly.
+
+Python says that _explicit is better than implicit_ for a reason, and with fabricate, we've made it so you tell it what you want. It won't do things behind your back based on the [83 different tools](http://www.scons.org/doc/HTML/scons-user/a9626.html) it may or may not know about.
+
+## Credits ##
+
+fabricate is inspired by [Bill McCloskey's memoize](http://www.eecs.berkeley.edu/~billm/memoize.html), but fabricate works under Windows as well by using file access times instead of strace if strace is not available on your file system. Read more about [how fabricate works.](HowItWorks.md)
+
+fabricate was originally developed by the B Hoyts at [Brush Technology](http://brush.co.nz/) for in-house use, and we then released into the wild. It now has a small but dedicated user base and is actively being maintained and improved by Simon Alford, with help from other fabricate users.
+
+## License ##
+
+Like memoize, fabricate is released under a [New BSD license](http://code.google.com/p/fabricate/wiki/License). fabricate is
+Copyright (c) 2009 Brush Technology.

--- a/test-requirement.txt
+++ b/test-requirement.txt
@@ -1,0 +1,7 @@
+mock==1.3.0
+plumbum==1.5.0
+pytest==2.8.1
+pytest-mock==0.8.1
+pytest-stepwise==0.3
+pytest-sugar==0.4.0
+robpol86-pytest-ipdb==0.0.1

--- a/test-requirement.txt
+++ b/test-requirement.txt
@@ -2,6 +2,3 @@ mock==1.3.0
 plumbum==1.5.0
 pytest==2.8.1
 pytest-mock==0.8.1
-pytest-stepwise==0.3
-pytest-sugar==0.4.0
-robpol86-pytest-ipdb==0.0.1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,99 @@
+import sys
+import pytest
+import os
+import shutil
+import atexit
+import json
+sys.path.append('.')
+from fabricate import *
+
+__all__ = [ 'runner_list', 'assert_same_json', 'assert_json_equality']
+
+runner_list = [StraceRunner, AtimesRunner]
+
+@pytest.fixture(autouse=True)
+def mock_env(request, mocker):
+    mocker.patch('sys.exit'
+                 )  # prevent sys.exit from existing so as to do other tests
+
+
+@pytest.fixture()
+def end_fabricate(request, monkeypatch):
+    """ This fixture replace atexit.register with its own local implementation
+    in order to allow one test to be fully executed (including atexit registred
+    functions) """
+    exithandlers = []
+
+    def testexit_register(func, *targs, **kargs):
+        exithandlers.append((func, targs, kargs))
+        return func
+
+    monkeypatch.setattr(atexit, 'register', testexit_register)
+
+    def run_exitfuncs():
+        exc_info = None
+        while exithandlers:
+            func, targs, kargs = exithandlers.pop()
+            try:
+                func(*targs, **kargs)
+            except SystemExit:
+                exc_info = sys.exc_info()
+            except:
+                import traceback
+                print >> sys.stderr, "Error in mock_env.run_exitfuncs:"
+                traceback.print_exc()
+                exc_info = sys.exc_info()
+        if exc_info is not None:
+            raise exc_info[0], exc_info[1], exc_info[2]
+
+    return run_exitfuncs
+
+
+@pytest.fixture
+def cleandir():
+    """ Sould the build directory be cleaned at the end of each test """
+    return True
+
+
+@pytest.fixture
+def builddir(request, cleandir):
+    bdir = os.path.join("build_dir", "%s-%s" % (request.module.__name__,
+                                                request.function.__name__))
+    try:
+        shutil.rmtree(bdir)
+    except OSError:
+        pass
+    os.makedirs(bdir)
+
+    def fin():
+        if cleandir:
+            shutil.rmtree(bdir, ignore_errors=True)
+
+    request.addfinalizer(fin)
+    return bdir
+
+
+def assert_same_json(depfile, depref):
+    """ Are the json in '.deps' `depfile` and the dict in `depref` equivalent
+    modulo the md5sum values """
+    assert_json_equality(depfile, depref, structural_only=True)
+
+def assert_json_equality(depfile, depref, structural_only=False):
+    """ Are the json in '.deps' `depfile` and the dict in `depref` equivalent """
+    def _replace_md5(d):
+        for k in d:
+            if isinstance(d[k], dict):
+                _replace_md5(d[k])
+            else:
+                if isinstance(d[k], basestring):
+                    if d[k].startswith("input-"):
+                        d[k] = d[k][:6]
+                    elif d[k].startswith("output-"):
+                        d[k] = d[k][:7]
+    with open(depfile, 'r') as  depfd:
+        out = json.load(depfd)
+    if structural_only:
+        _replace_md5(out)
+        _replace_md5(depref)
+    assert out == depref
+

--- a/test/test_fabricate.py
+++ b/test/test_fabricate.py
@@ -6,105 +6,15 @@ import pytest
 import plumbum.cmd as sh
 from plumbum import local
 import os
-import shutil
-import json
-import atexit
 from copy import copy
 
-sys.path.append('.')
 
 from fabricate import *
 from fabricate import md5func
+from conftest import *
 EMPY_FILE_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
 
-runner_list = [StraceRunner, AtimesRunner]
 
-
-@pytest.fixture(autouse=True)
-def mock_env(request, mocker):
-    mocker.patch('sys.exit'
-                 )  # prevent sys.exit from existing so as to do other tests
-
-
-@pytest.fixture()
-def end_fabricate(request, monkeypatch):
-    """ This fixture replace atexit.register with its own local implementation
-    in order to allow one test to be fully executed (including atexit registred
-    functions) """
-    exithandlers = []
-
-    def testexit_register(func, *targs, **kargs):
-        exithandlers.append((func, targs, kargs))
-        return func
-
-    monkeypatch.setattr(atexit, 'register', testexit_register)
-
-    def run_exitfuncs():
-        exc_info = None
-        while exithandlers:
-            func, targs, kargs = exithandlers.pop()
-            try:
-                func(*targs, **kargs)
-            except SystemExit:
-                exc_info = sys.exc_info()
-            except:
-                import traceback
-                print >> sys.stderr, "Error in mock_env.run_exitfuncs:"
-                traceback.print_exc()
-                exc_info = sys.exc_info()
-        if exc_info is not None:
-            raise exc_info[0], exc_info[1], exc_info[2]
-
-    return run_exitfuncs
-
-
-@pytest.fixture
-def cleandir():
-    """ Sould the build directory be cleaned at the end of each test """
-    return True
-
-
-@pytest.fixture
-def builddir(request, cleandir):
-    bdir = os.path.join("build_dir", "%s-%s" % (request.module.__name__,
-                                                request.function.__name__))
-    try:
-        shutil.rmtree(bdir)
-    except OSError:
-        pass
-    os.makedirs(bdir)
-
-    def fin():
-        if cleandir:
-            shutil.rmtree(bdir, ignore_errors=True)
-
-    request.addfinalizer(fin)
-    return bdir
-
-
-def assert_same_json(depfile, depref):
-    """ Are the json in '.deps' `depfile` and the dict in `depref` equivalent
-    modulo the md5sum values """
-    assert_json_equality(depfile, depref, structural_only=True)
-
-def assert_json_equality(depfile, depref, structural_only=False):
-    """ Are the json in '.deps' `depfile` and the dict in `depref` equivalent """
-    def _replace_md5(d):
-        for k in d:
-            if isinstance(d[k], dict):
-                _replace_md5(d[k])
-            else:
-                if isinstance(d[k], basestring):
-                    if d[k].startswith("input-"):
-                        d[k] = d[k][:6]
-                    elif d[k].startswith("output-"):
-                        d[k] = d[k][:7]
-    with open(depfile, 'r') as  depfd:
-        out = json.load(depfd)
-    if structural_only:
-        _replace_md5(out)
-        _replace_md5(depref)
-    assert out == depref
 
 
 @pytest.mark.parametrize("runner", runner_list)
@@ -128,7 +38,7 @@ def test_create(builddir, runner, end_fabricate):
          runner=runner,
          command_line=['-c', '-D', 'build'])
     end_fabricate()
-    #atexit._run_exitfuncs()
+
     expected_json = {'tar czvf foo.tar.gz a.c b.c':
         {'b.c': 'input-',
          'foo.tar.gz': 'output-',

--- a/test/test_fabricate.py
+++ b/test/test_fabricate.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import pytest
+import plumbum.cmd as sh
+from plumbum import local
+import os
+import shutil
+import json
+import atexit
+from copy import copy
+
+sys.path.append('.')
+
+from fabricate import *
+from fabricate import md5func
+EMPY_FILE_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
+
+runner_list = [StraceRunner, AtimesRunner]
+
+
+@pytest.fixture(autouse=True)
+def mock_env(request, mocker):
+    mocker.patch('sys.exit'
+                 )  # prevent sys.exit from existing so as to do other tests
+
+
+@pytest.fixture()
+def end_fabricate(request, monkeypatch):
+    """ This fixture replace atexit.register with its own local implementation
+    in order to allow one test to be fully executed (including atexit registred
+    functions) """
+    exithandlers = []
+
+    def testexit_register(func, *targs, **kargs):
+        exithandlers.append((func, targs, kargs))
+        return func
+
+    monkeypatch.setattr(atexit, 'register', testexit_register)
+
+    def run_exitfuncs():
+        exc_info = None
+        while exithandlers:
+            func, targs, kargs = exithandlers.pop()
+            try:
+                func(*targs, **kargs)
+            except SystemExit:
+                exc_info = sys.exc_info()
+            except:
+                import traceback
+                print >> sys.stderr, "Error in mock_env.run_exitfuncs:"
+                traceback.print_exc()
+                exc_info = sys.exc_info()
+        if exc_info is not None:
+            raise exc_info[0], exc_info[1], exc_info[2]
+
+    return run_exitfuncs
+
+
+@pytest.fixture
+def cleandir():
+    """ Sould the build directory be cleaned at the end of each test """
+    return True
+
+
+@pytest.fixture
+def builddir(request, cleandir):
+    bdir = os.path.join("build_dir", "%s-%s" % (request.module.__name__,
+                                                request.function.__name__))
+    try:
+        shutil.rmtree(bdir)
+    except OSError:
+        pass
+    os.makedirs(bdir)
+
+    def fin():
+        if cleandir:
+            shutil.rmtree(bdir, ignore_errors=True)
+
+    request.addfinalizer(fin)
+    return bdir
+
+
+def assert_same_json(depfile, depref):
+    """ Are the json in '.deps' `depfile` and the dict in `depref` equivalent
+    modulo the md5sum values """
+    assert_json_equality(depfile, depref, structural_only=True)
+
+def assert_json_equality(depfile, depref, structural_only=False):
+    """ Are the json in '.deps' `depfile` and the dict in `depref` equivalent """
+    def _replace_md5(d):
+        for k in d:
+            if isinstance(d[k], dict):
+                _replace_md5(d[k])
+            else:
+                if isinstance(d[k], basestring):
+                    if d[k].startswith("input-"):
+                        d[k] = d[k][:6]
+                    elif d[k].startswith("output-"):
+                        d[k] = d[k][:7]
+    with open(depfile, 'r') as  depfd:
+        out = json.load(depfd)
+    if structural_only:
+        _replace_md5(out)
+        _replace_md5(depref)
+    assert out == depref
+
+
+@pytest.mark.parametrize("runner", runner_list)
+def test_create(builddir, runner, end_fabricate):
+    # prepare needed files
+    with local.cwd(builddir):
+        (sh.echo["a.c"] > "a.c")()
+        (sh.echo["b.c"] > "b.c")()
+
+    # build.py content >>>>>>>>>>>>>>>>>>>>>
+    def fabricate_file():
+        def build():
+            run('tar', 'czvf', 'foo.tar.gz', 'a.c', 'b.c')
+
+        def clean():
+            autoclean()
+        return copy(locals())
+
+    main(globals_dict=fabricate_file(),
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-c', '-D', 'build'])
+    end_fabricate()
+    #atexit._run_exitfuncs()
+    expected_json = {'tar czvf foo.tar.gz a.c b.c':
+        {'b.c': 'input-',
+         'foo.tar.gz': 'output-',
+         'a.c': 'input-'},
+     u'.deps_version': 2}
+
+
+    # assertions
+    with local.cwd(builddir):
+        assert_same_json('.deps', expected_json)
+        assert os.path.isfile('foo.tar.gz')
+        assert sh.tar("tf", 'foo.tar.gz') == "a.c\nb.c\n"
+        print(sh.ls("-al"))
+        assert '"a.c": "input-' in sh.cat(".deps")
+        sys.exit.assert_called_once_with(0)
+
+
+        # Modify a.c to force rebuilding
+        (sh.echo["newline"] > "a.c")()
+
+    main(globals_dict=fabricate_file(),
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'build'])
+    end_fabricate()
+
+    with local.cwd(builddir):
+        sh.tar("df", "foo.tar.gz") # ensure tar diff return no difference
+
+
+@pytest.mark.parametrize("runner", runner_list)
+def test_mkdir(builddir, runner, end_fabricate):
+
+    # build.py content >>>>>>>>>>>>>>>>>>>>>
+    def fabricate_file():
+        def build():
+            # Make lots of directories to check ordered delete
+            run('mkdir', 'testdir', group='testdir')
+            run('mkdir', 'testdir/a', group='a', after='testdir')
+            run('mkdir', 'testdir/b', group='b', after='testdir')
+            run('mkdir', 'testdir/c', group='c', after='testdir')
+            run('mkdir', 'testdir/c/f', group='f', after='c')
+            run('mkdir', 'testdir/c/e', group='e', after='c')
+            run('mkdir', 'testdir/c/d', group='d', after='c')
+
+            # put some files in them to ensure content deleted before dir
+            run('touch', 'testdir/f1', after='testdir')
+            run('touch', 'testdir/f2', after='testdir')
+            run('touch', 'testdir/b/f1', after='b')
+            run('touch', 'testdir/b/f2', after='b')
+            run('touch', 'testdir/c/d/f1', after='d')
+            run('touch', 'testdir/c/d/f2', after='d')
+
+            # make a dir that alreay exists
+            run('mkdir', '-p', 'testdir/c/d', after='d')
+
+            # make a dir that already partialy exists
+            run('mkdir', '-p', 'testdir/c/g', after='c')
+
+            # make a dir that already partialy exists but should not be deleted
+            run('mkdir', '-p', 'existingdir/a')
+
+        def clean():
+            autoclean()
+
+        return copy(locals())
+
+    with local.cwd(builddir):
+        sh.mkdir('existingdir')
+        sh.touch('existingdir/existingfile')
+
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'build'])
+    end_fabricate()
+
+    expected_json = {
+        ".deps_version": 2,
+        "mkdir -p existingdir/a": {
+            "existingdir": "input-ae394c47b4ccf49007dc9ec847f657b9",
+            "existingdir/a": "output-16873f5a4ba5199a8b51f812d159e37e"
+        },
+        "mkdir -p testdir/c/d": {
+            "testdir": "input-3ca0a3620b59afb57cf5fd77cee6432c",
+            "testdir/c": "input-54a9057bcd619534a49f669dd5ed3078",
+            "testdir/c/d": "input-fdb1b8414eeab993acc5623371c43a71"
+        },
+        "mkdir -p testdir/c/g": {
+            "testdir": "input-3ca0a3620b59afb57cf5fd77cee6432c",
+            "testdir/c": "input-54a9057bcd619534a49f669dd5ed3078",
+            "testdir/c/g": "output-c512be1476c9253326e479827c491f7f"
+        },
+        "mkdir testdir": {
+            "testdir": "output-3ca0a3620b59afb57cf5fd77cee6432c"
+        },
+        "mkdir testdir/a": {
+            "testdir/a": "output-832651e32363cb4b115b074240cd08b5"
+        },
+        "mkdir testdir/b": {
+            "testdir/b": "output-0432d5c3dc41495725df46eeeedb1386"
+        },
+        "mkdir testdir/c": {
+            "testdir/c": "output-54a9057bcd619534a49f669dd5ed3078"
+        },
+        "mkdir testdir/c/d": {
+            "testdir/c/d": "output-fdb1b8414eeab993acc5623371c43a71"
+        },
+        "mkdir testdir/c/e": {
+            "testdir/c/e": "output-eadea986453292aaa62ccde2312c3413"
+        },
+        "mkdir testdir/c/f": {
+            "testdir/c/f": "output-5d7c7f98e6d795bbb252f6866c8d7850"
+        },
+        "touch testdir/b/f1": {
+            "testdir/b/f1": "output-d41d8cd98f00b204e9800998ecf8427e"
+        },
+        "touch testdir/b/f2": {
+            "testdir/b/f2": "output-d41d8cd98f00b204e9800998ecf8427e"
+        },
+        "touch testdir/c/d/f1": {
+            "testdir/c/d/f1": "output-d41d8cd98f00b204e9800998ecf8427e"
+        },
+        "touch testdir/c/d/f2": {
+            "testdir/c/d/f2": "output-d41d8cd98f00b204e9800998ecf8427e"
+        },
+        "touch testdir/f1": {
+            "testdir/f1": "output-d41d8cd98f00b204e9800998ecf8427e"
+        },
+        "touch testdir/f2": {
+            "testdir/f2": "output-d41d8cd98f00b204e9800998ecf8427e"
+        }
+    }
+
+    # assertions
+    with local.cwd(builddir):
+        assert_json_equality('.deps', expected_json)
+        assert os.path.isdir('testdir/c/g')
+        assert os.path.isfile('testdir/c/d/f2')
+        assert os.path.isdir('existingdir/a')
+        sys.exit.assert_called_once_with(0)
+
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         #jobs=4,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'clean'])
+    end_fabricate()
+
+    with local.cwd(builddir):
+        assert not os.path.isdir('testdir')
+        assert os.path.isdir('existingdir')
+        assert os.path.isfile('existingdir/existingfile')
+        assert not os.path.isdir('existingdir/a')
+
+
+
+# Builder.done compute the hash after the file has been removed !
+# Thus dependency is lost, and the mv command is not applied when originalfile
+# is changed
+@pytest.mark.xfail
+@pytest.mark.parametrize("runner", runner_list)
+def test_rename(builddir, runner, end_fabricate):
+
+    # build.py content >>>>>>>>>>>>>>>>>>>>>
+    def fabricate_file():
+        def build():
+            run('mv', 'originalfile', 'testfile')
+
+        def clean():
+            autoclean()
+            # remake the original file
+            shell('touch', 'originalfile')
+
+        return copy(locals())
+
+    with local.cwd(builddir):
+        sh.touch('originalfile')
+
+    ###### First build ##########
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'build'])
+    end_fabricate()
+
+    expected_json = {
+            ".deps_version": 2,
+            "mv originalfile testfile": {
+                "originalfile": "input-d41d8cd98f00b204e9800998ecf8427e",
+                "testfile": "output-d41d8cd98f00b204e9800998ecf8427e"
+            }
+        }
+
+    # assertions
+    with local.cwd(builddir):
+        assert_json_equality('.deps', expected_json)
+        assert os.path.isfile('testfile')
+        sys.exit.assert_called_once_with(0)
+
+        # update original file to check the rebuild
+        (sh.echo["newline"] > "originalfile")()
+
+    ###### Second build ##########
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         #jobs=4,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'build'])
+    end_fabricate()
+
+    expected_json = {
+            ".deps_version": 2,
+            "mv originalfile testfile": {
+                "originalfile": "input-321060ae067e2a25091be3372719e053",
+                "testfile": "output-321060ae067e2a25091be3372719e053"
+            }
+        }
+
+    with local.cwd(builddir):
+        assert_json_equality('.deps', expected_json)
+        assert "newline" in sh.cat('testfile')
+
+
+    ###### Cleaning ##########
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         #jobs=4,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'clean'])
+    end_fabricate()
+
+    with local.cwd(builddir):
+        assert not os.isfile('testfile')
+        assert os.isfile('originalfile')
+
+@pytest.mark.parametrize("runner", runner_list)
+def test_symlink(builddir, runner, end_fabricate):
+
+    # build.py content >>>>>>>>>>>>>>>>>>>>>
+    def fabricate_file():
+        def build():
+            run('ln', '-s', 'testfile', 'testlink')
+            run('ln', '-s', 'testdir', 'testlink_dir')
+            run('ln', '-s', 'nofile', 'testlink_nofile')
+
+        def clean():
+            autoclean()
+
+        return copy(locals())
+
+    with local.cwd(builddir):
+        sh.touch('testfile')
+        sh.mkdir('testdir')
+
+    ###### First build ##########
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'build'])
+    end_fabricate()
+
+    expected_json = {
+        ".deps_version": 2,
+        "ln -s nofile testlink_nofile": {
+            "testlink_nofile": "output-"
+        },
+        "ln -s testdir testlink_dir": {
+            "testlink_dir": "output-"
+        },
+        "ln -s testfile testlink": {
+            "testlink": "output-"
+        }
+    }
+
+    # assertions
+    with local.cwd(builddir):
+        assert_same_json('.deps', expected_json)
+        assert os.path.islink('testlink')
+        assert os.path.realpath('testlink').endswith('/testfile')
+        assert os.path.islink('testlink_dir')
+        assert os.path.realpath('testlink_dir').endswith('/testdir')
+        assert os.path.islink('testlink_nofile')
+        assert not os.path.isfile('testlink_nofile')
+        sys.exit.assert_called_once_with(0)
+
+    ###### Cleaning ##########
+    main(globals_dict=fabricate_file(),
+         #parallel_ok=True,
+         #jobs=4,
+         build_dir=builddir,
+         runner=runner,
+         command_line=['-D', 'clean'])
+    end_fabricate()
+
+    with local.cwd(builddir):
+        assert not os.path.isfile('.deps')
+        assert not os.path.islink('testlink')
+        assert not os.path.islink('testlink_dir')
+        assert not os.path.islink('testlink_nofile')
+
+def test_md5_hasher(builddir):
+    with local.cwd(builddir):
+        sh.touch('testfile')
+        sh.mkdir('testdir')
+        sh.touch('testdir/testfile')
+        sh.ln('-s', 'testdir', 'testdirlink')
+        sh.ln('-s', 'testfile', 'testlink')
+        sh.ln('-s', 'nofile', 'testlink_nofile')
+        assert md5_hasher('nofile') == None
+        assert md5_hasher('testfile') == EMPY_FILE_MD5
+        assert md5_hasher('testdir') == md5func('testdir').hexdigest()
+        assert md5_hasher('testlink') == EMPY_FILE_MD5
+        assert md5_hasher('testdirlink') == md5func('testdir').hexdigest()
+        assert md5_hasher('testlink_nofile') == md5func('nofile').hexdigest()
+
+


### PR DESCRIPTION
This PR ported the existing tests as an automated py.test file in `test/test_fabricate.py`, and add a travis configuration file to allow continuous integration on Travis.

The current status  is not so good : 

```
test/test_fabricate.py::test_create[StraceRunner] FAILED
test/test_fabricate.py::test_create[AtimesRunner] PASSED
test/test_fabricate.py::test_mkdir[StraceRunner] PASSED
test/test_fabricate.py::test_mkdir[AtimesRunner] FAILED
test/test_fabricate.py::test_rename[StraceRunner] xfail
test/test_fabricate.py::test_rename[AtimesRunner] xfail
test/test_fabricate.py::test_symlink[StraceRunner] PASSED
test/test_fabricate.py::test_symlink[AtimesRunner] FAILED
test/test_fabricate.py::test_md5_hasher PASSED
```

The StraceRunner failed tests may be linked to existing issues like #42.
The rename tests are written as "expected failed", because the dependency on the origine file is never recorded (issue to be opened).
I'm not sure about the AtimesRunne issues.
