### PR TITLE
Add Python 3.6 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ python:
    - "3.3"
    - "3.4"
    - "3.5"
+   - "3.6"
 # command to install dependencies
 before_install:
    - sudo apt-get update -qq
    - sudo apt-get install -y strace
+   - pip install --upgrade pip
 install: "pip install -r test-requirement.txt"
 # command to run tests
 script: py.test


### PR DESCRIPTION
 To enable Travis CI, go into repo settings, Integrations and Services, and Add Travis CI and enable it for this repo. It will then be free and automatic on all Pull Requests.