### PR TITLE
Python 3.7 fix install + declare CLI entry_point in setup.py

### DIFF
--- a/fabricate.py
+++ b/fabricate.py
@@ -1607,7 +1607,8 @@ def main(globals_dict=None, build_dir=None, extra_options=None, builder=None,
         os.chdir(original_path)
     sys.exit(status)
 
-if __name__ == '__main__':
+
+def cli():
     # if called as a script, emulate memoize.py -- run() command line
     parser, options, args = parse_options('[options] command line to run')
     status = 0
@@ -1618,3 +1619,6 @@ if __name__ == '__main__':
         status = 1
     # autoclean may have been used
     sys.exit(status)
+
+if __name__ == '__main__':
+    cli()

--- a/fabricate.py
+++ b/fabricate.py
@@ -50,7 +50,7 @@ except ImportError:
             raise NotImplementedError("multiprocessing module not available, can't do parallel builds")
     multiprocessing = MultiprocessingModule()
 
-# compatibility            
+# compatibility
 PY3 = sys.version_info[0] == 3
 if PY3:
     string_types = str
@@ -784,10 +784,10 @@ class SmartRunner(Runner):
 class _running(object):
     """ Represents a task put on the parallel pool
         and its results when complete """
-    def __init__(self, async, command):
-        """ "async" is the AsyncResult object returned from pool.apply_async
+    def __init__(self, async_, command):
+        """ "async_" is the AsyncResult object returned from pool.apply_async
             "command" is the command that was run """
-        self.async = async
+        self.async_ = async_
         self.command = command
         self.results = None
 
@@ -924,9 +924,9 @@ def _results_handler( builder, delay=0.01):
             for id in _groups.ids():
                 if id is False: continue # key of False is _afters not _runnings
                 for r in _groups.item_list(id):
-                    if r.results is None and r.async.ready():
+                    if r.results is None and r.async_.ready():
                         try:
-                            d, o = r.async.get()
+                            d, o = r.async_.get()
                         except ExecutionError as e:
                             r.results = e
                             _groups.set_ok(id, False)
@@ -945,9 +945,9 @@ def _results_handler( builder, delay=0.01):
                 if still_to_do == 0:
                     if isinstance(a.do, _todo):
                         if no_error:
-                            async = _pool.apply_async(_call_strace, a.do.arglist,
+                            async_ = _pool.apply_async(_call_strace, a.do.arglist,
                                         a.do.kwargs)
-                            _groups.add_for_blocked(a.do.group, _running(async, a.do.command))
+                            _groups.add_for_blocked(a.do.group, _running(async_, a.do.command))
                         else:
                             # Mark the command as not done due to errors
                             r = _running(None, a.do.command)
@@ -1132,8 +1132,8 @@ class Builder(object):
                             _after(after, _todo(group, command, arglist,
                                                 kwargs)))
             else:
-                async = _pool.apply_async(_call_strace, arglist, kwargs)
-                _groups.add(group, _running(async, command))
+                async_ = _pool.apply_async(_call_strace, arglist, kwargs)
+                _groups.add(group, _running(async_, command))
             return None
         else:
             deps, outputs = self.runner(*arglist, **kwargs)

--- a/fabricate.py
+++ b/fabricate.py
@@ -60,7 +60,7 @@ else:
 
 try:
     threading_condition = threading._Condition
-except ImportError:
+except (ImportError, AttributeError):
     threading_condition = threading.Condition
 
 # so you can do "from fabricate import *" to simplify your build script

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ setup(
     url='https://github.com/SimonAlfie/fabricate/',
     py_modules=['fabricate'],
 
+    entry_points={
+        'console_scripts': [
+            'fabricate = fabricate:cli',
+        ],
+    },
+
     extras_require=dict(
         build=['twine', 'wheel', 'setuptools-git', 'pypandoc'],
     ),


### PR DESCRIPTION
Fixes pip install on Arch Linux / Python 3.7:

```
Collecting fabricate
  Downloading https://files.pythonhosted.org/packages/2d/8c/54300f46c6eed4494b29a32c8a1f1efa2f8f773c13cacaeda04e510b7c42/fabricate-1.29.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-qdelu7d5/fabricate/setup.py", line 3, in <module>
        from fabricate import __version__
      File "/tmp/pip-install-qdelu7d5/fabricate/fabricate.py", line 779
        def __init__(self, async, command):
                               ^
    SyntaxError: invalid syntax
```

and

```
Obtaining file:///home/jpic/src/fabricate
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/jpic/src/fabricate/setup.py", line 3, in <module>
        from fabricate import __version__
      File "/home/jpic/src/fabricate/fabricate.py", line 62, in <module>
        threading_condition = threading._Condition
    AttributeError: module 'threading' has no attribute '_Condition'
```