### PR TITLE
Check if AtimesRunner works with directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
    - sudo apt-get install -y strace
 install: "pip install -r test-requirement.txt"
 # command to run tests
-script: pytest
+script: pytest -v

--- a/test-requirement.txt
+++ b/test-requirement.txt
@@ -1,4 +1,4 @@
 mock==2.0.0
 plumbum==1.6.3
-pytest==3.0.7
+pytest==4.3.0
 pytest-mock==1.5.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ import shutil
 import atexit
 import json
 import inspect
+import tempfile
 
 sys.path.append('.')
 
@@ -16,7 +17,15 @@ from _pytest.monkeypatch import MonkeyPatch
 
 __all__ = [ 'runner_list', 'assert_same_json', 'assert_json_equality', 'FabricateBuild']
 
-runner_list = [StraceRunner, AtimesRunner]
+possible_runner_list = [StraceRunner, AtimesRunner]
+runner_list = []
+temp_dir = tempfile.mkdtemp()
+for r in possible_runner_list:
+    try:
+        if r(fabricate.Builder(dirs=[temp_dir])):
+            runner_list.append(r)
+    except fabricate.RunnerUnsupportedException:
+        runner_list.append(pytest.param(r, marks=pytest.mark.skip))
 
 try:
     string_types = (basestring,)


### PR DESCRIPTION
This builds on #94 to fix the issues in #97 with AtimesRunner and then skip runners that don't work on the current platform (which, because of the issues in #97 is currently every platform for AtimesRunner)